### PR TITLE
osd: fixed slider control not working on video osd

### DIFF
--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -237,91 +237,10 @@
                 <texture>osd/btn_pause.png</texture>
             </control>
         </control>
-
-        <control type="group" id="4010">
-            <posx>0</posx>
-            <posy>984</posy>
-            <visible>[!Player.Paused + Player.DisplayAfterSeek] | Window.IsActive(videoosd)</visible>
-            <animation type="VisibleChange" reversible="false">
-                <effect type="fade" start="0" end="100" time="200" />
-            </animation>
-            <control type="image">
-                <posx>0</posx>
-                <posy>-184</posy>
-                <width>1920</width>
-                <height>280</height>
-                <texture>views/landscape/shade.png</texture>
-            </control>
-            <control type="label">
-                <posx>0</posx>
-                <posy>-60</posy>
-                <width>1920</width>
-                <height>96</height>
-                <align>left</align>
-                <font>Medium_Caps</font>
-                <textcolor>White2</textcolor>
-                <label>$INFO[Player.Chapter,$LOCALIZE[21396]: ]$INFO[Player.ChapterCount, / ]</label>
-                <textoffsetx>30</textoffsetx>
-                <visible>Player.ChapterCount</visible>
-            </control>
-            <control type="label">
-                <posx>256</posx>
-                <posy>0</posy>
-                <width>256</width>
-                <height>96</height>
-                <align>right</align>
-                <font>Medium_Caps3</font>
-                <textcolor>White2</textcolor>
-                <label>$INFO[Player.Time]</label>
-                <textoffsetx>30</textoffsetx>
-            </control>
-            <control type="label">
-                <posx>1644</posx>
-                <posy>0</posy>
-                <width>1680</width>
-                <height>96</height>
-                <font>Medium_Caps3</font>
-                <label>$VAR[TimeRemainingVar]</label>
-                <textcolor>White2</textcolor>
-                <textoffsetx>30</textoffsetx>
-            </control>
-            <control type="progress">
-                <description>Progress Bar</description>
-                <posx>260</posx>
-                <posy>40</posy>
-                <width>1400</width>
-                <info>Player.ProgressCache</info>
-                <visible>true</visible>
-                <midtexture border="1">common/texturesliderbar.png</midtexture>
-                <righttexture border="1">common/texturesliderbar.png</righttexture>
-            </control>
-            <control type="progress" id="23">
-                <description>Progress Bar</description>
-                <posx>260</posx>
-                <posy>40</posy>
-                <width>1400</width>
-                <info>Player.Progress</info>
-                <visible>true</visible>
-                <texturebg border="2">settings/texturebg_cache.png</texturebg>
-                <righttexture border="0,0,26,0">-</righttexture>
-                <colordiffuse>Blue2</colordiffuse>
-            </control>
-            <control type="slider" id="24">
-                <description>Seekbar</description>
-                <posx>260</posx>
-                <posy>20</posy>
-                <width>1400</width>
-                <height>66</height>
-                <texturesliderbar border="2">settings/texturebg_slider.png</texturesliderbar>
-                <textureslidernib>osd/slider_nf.png</textureslidernib>
-                <textureslidernibfocus>osd/slider.png</textureslidernibfocus>
-                <controloffsetx>0</controloffsetx>
-                <controloffsety>0</controloffsety>
-                <action>seek</action>
-                <info>player.progress</info>
-                <visible>true</visible>
-                <colordiffuse>Blue2</colordiffuse>
-            </control>
+		
+		<control type="group">
+			<visible>[!Player.Paused + Player.DisplayAfterSeek] + !Window.IsActive(VideoOSD)</visible>
+        	<include>SliderControl</include>
         </control>
 
         <control type="group">

--- a/1080i/MusicOSD.xml
+++ b/1080i/MusicOSD.xml
@@ -344,68 +344,8 @@
                 <height>280</height>
                 <texture>views/landscape/shade.png</texture>
             </control>
-
-
-            <control type="group">
-                <posx>0</posx>
-                <posy>984</posy>
-                <control type="label">
-                    <posx>256</posx>
-                    <posy>0</posy>
-                    <width>256</width>
-                    <height>96</height>
-                    <align>right</align>
-                    <font>Medium_Caps3</font>
-                    <label>$INFO[Player.Time]</label>
-                    <textoffsetx>8</textoffsetx>
-                </control>
-                <control type="label">
-                    <posx>1664</posx>
-                    <posy>0</posy>
-                    <width>1680</width>
-                    <height>96</height>
-                    <label>$INFO[Player.Duration]</label>
-                    <textoffsetx>8</textoffsetx>
-                    <font>Medium_Caps3</font>
-                </control>
-                <control type="progress">
-                    <description>Progress Bar</description>
-                    <posx>260</posx>
-                    <posy>40</posy>
-                    <width>1400</width>
-                    <info>Player.ProgressCache</info>
-                    <visible>true</visible>
-                    <midtexture border="1">common/texturesliderbar.png</midtexture>
-                    <righttexture border="1">common/texturesliderbar.png</righttexture>
-                </control>
-                <control type="progress" id="23">
-                    <description>Progress Bar</description>
-                    <posx>260</posx>
-                    <posy>40</posy>
-                    <width>1400</width>
-                    <info>Player.Progress</info>
-                    <visible>true</visible>
-                    <texturebg border="2">settings/texturebg_cache.png</texturebg>
-                    <righttexture border="0,0,26,0">-</righttexture>
-                    <colordiffuse>Blue2</colordiffuse>
-                </control>
-                <control type="slider" id="24">
-                    <description>Seekbar</description>
-                    <posx>260</posx>
-                    <posy>20</posy>
-                    <width>1400</width>
-                    <height>66</height>
-                    <texturesliderbar border="2">settings/texturebg_slider.png</texturesliderbar>
-                    <textureslidernib>osd/slider_nf.png</textureslidernib>
-                    <textureslidernibfocus>osd/slider.png</textureslidernibfocus>
-                    <controloffsetx>0</controloffsetx>
-                    <controloffsety>0</controloffsety>
-                    <action>seek</action>
-                    <info>player.progress</info>
-                    <visible>true</visible>
-                    <colordiffuse>Blue2</colordiffuse>
-                </control>
-            </control>
+			
+			<include>SliderControl</include>
         </control>
     </controls>
 </window>

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -271,6 +271,8 @@
                 </control>
 			</control>
 		</control>
+		
+		<include>SliderControl</include>
 
         <control type="group">
             <animation type="WindowOpen" reversible="false">

--- a/1080i/includes.xml
+++ b/1080i/includes.xml
@@ -977,4 +977,92 @@
         <bordertexture border="21">thumbs/thumb_shadow.png</bordertexture>
         <bordersize>21</bordersize>
     </include>
+    
+    <include name="SliderControl">
+	    <control type="group" id="4010">
+	    	<description>Slider Control</description>
+	        <posx>0</posx>
+	        <posy>984</posy>
+	        <animation type="VisibleChange" reversible="false">
+	            <effect type="fade" start="0" end="100" time="200" />
+	        </animation>
+	        <control type="image">
+	            <posx>0</posx>
+	            <posy>-184</posy>
+	            <width>1920</width>
+	            <height>280</height>
+	            <texture>views/landscape/shade.png</texture>
+	        </control>
+	        <control type="label">
+	            <posx>0</posx>
+	            <posy>-60</posy>
+	            <width>1920</width>
+	            <height>96</height>
+	            <align>left</align>
+	            <font>Medium_Caps</font>
+	            <textcolor>White2</textcolor>
+	            <label>$INFO[Player.Chapter,$LOCALIZE[21396]: ]$INFO[Player.ChapterCount, / ]</label>
+	            <textoffsetx>30</textoffsetx>
+	            <visible>Player.ChapterCount</visible>
+	        </control>
+	        <control type="label">
+	            <posx>256</posx>
+	            <posy>0</posy>
+	            <width>256</width>
+	            <height>96</height>
+	            <align>right</align>
+	            <font>Medium_Caps3</font>
+	            <textcolor>White2</textcolor>
+	            <label>$INFO[Player.Time]</label>
+	            <textoffsetx>30</textoffsetx>
+	        </control>
+	        <control type="label">
+	            <posx>1644</posx>
+	            <posy>0</posy>
+	            <width>1680</width>
+	            <height>96</height>
+	            <font>Medium_Caps3</font>
+	            <label>$VAR[TimeRemainingVar]</label>
+	            <textcolor>White2</textcolor>
+	            <textoffsetx>30</textoffsetx>
+	        </control>
+	        <control type="progress">
+	            <description>Progress Bar</description>
+	            <posx>260</posx>
+	            <posy>40</posy>
+	            <width>1400</width>
+	            <info>Player.ProgressCache</info>
+	            <visible>true</visible>
+	            <midtexture border="1">common/texturesliderbar.png</midtexture>
+	            <righttexture border="1">common/texturesliderbar.png</righttexture>
+	        </control>
+	        <control type="progress" id="23">
+	            <description>Progress Bar</description>
+	            <posx>260</posx>
+	            <posy>40</posy>
+	            <width>1400</width>
+	            <info>Player.Progress</info>
+	            <visible>true</visible>
+	            <texturebg border="2">settings/texturebg_cache.png</texturebg>
+	            <righttexture border="0,0,26,0">-</righttexture>
+	            <colordiffuse>Blue2</colordiffuse>
+	        </control>
+	        <control type="slider" id="24">
+	            <description>Seekbar</description>
+	            <posx>260</posx>
+	            <posy>20</posy>
+	            <width>1400</width>
+	            <height>66</height>
+	            <texturesliderbar border="2">settings/texturebg_slider.png</texturesliderbar>
+	            <textureslidernib>osd/slider_nf.png</textureslidernib>
+	            <textureslidernibfocus>osd/slider.png</textureslidernibfocus>
+	            <controloffsetx>0</controloffsetx>
+	            <controloffsety>0</controloffsety>
+	            <action>seek</action>
+	            <info>player.progress</info>
+	            <visible>true</visible>
+	            <colordiffuse>Blue2</colordiffuse>
+	        </control>
+	    </control>
+    </include>
 </includes>


### PR DESCRIPTION
The slider control is not working if it's not included within the
VideoOSD. This PR refactor the slider control into an include and use
it on DialogSeekBar and VideoOSD. Now you can use the slider control to
seek as expected.
