### PR TITLE
osd: invert play/pause button

### DIFF
--- a/1080i/MusicOSD.xml
+++ b/1080i/MusicOSD.xml
@@ -324,7 +324,7 @@
                     <posy>0</posy>
                     <width>186</width>
                     <height>186</height>
-                    <texture>osd/btn_play.png</texture>
+                    <texture>osd/btn_pause.png</texture>
                     <visible>!Player.Paused</visible>
                 </control>
                 <control type="image">
@@ -332,7 +332,7 @@
                     <posy>0</posy>
                     <width>186</width>
                     <height>186</height>
-                    <texture>osd/btn_pause.png</texture>
+                    <texture>osd/btn_play.png</texture>
                     <visible>Player.Paused</visible>
                 </control>
             </control>

--- a/1080i/MusicVisualisation.xml
+++ b/1080i/MusicVisualisation.xml
@@ -497,7 +497,7 @@
                     <posy>0</posy>
                     <width>186</width>
                     <height>186</height>
-                    <texture>osd/btn_pause.png</texture>
+                    <texture>osd/btn_play.png</texture>
                 </control>
             </control>
 

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -305,7 +305,7 @@
                     <posy>0</posy>
                     <width>186</width>
                     <height>186</height>
-                    <texture>osd/btn_play.png</texture>
+                    <texture>osd/btn_pause.png</texture>
                     <visible>!Player.Paused</visible>
                 </control>
                 <control type="image">
@@ -313,7 +313,7 @@
                     <posy>0</posy>
                     <width>186</width>
                     <height>186</height>
-                    <texture>osd/btn_pause.png</texture>
+                    <texture>osd/btn_play.png</texture>
                     <visible>Player.Paused</visible>
                 </control>
             </control>


### PR DESCRIPTION
This PR inverts the play/pause button, so the button indicates the
action which is triggered instead of the current playing state.
This fits to the normal behavior in most players on android.
